### PR TITLE
closes #79

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: runner
 Title: Running Operations for Vectors
 Type: Package
-Version: 0.4.0
+Version: 0.4.1
 Depends: R (>= 3.0)
 Language: en-US
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# runner 0.4.1
+* Fix `runner.grouped_df` (`dplyr` class) to not ignore `k` argument.
+
 # runner 0.4.0
 * defunct `type` argument in favor of `simplify`.
 * fixed error when using `runner::runner`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # runner 0.4.1
 * Fix `runner.grouped_df` (`dplyr` class) to not ignore `k` argument.
+* removed defunct argument `type`.
 
 # runner 0.4.0
 * defunct `type` argument in favor of `simplify`.

--- a/R/run.R
+++ b/R/run.R
@@ -427,6 +427,7 @@ runner.grouped_df <- function(
   runner.data.frame(
     x = this_group(x),
     f = f,
+    k = k,
     lag = lag,
     idx = idx,
     at = at,

--- a/R/run.R
+++ b/R/run.R
@@ -1,7 +1,7 @@
 #' Apply running function
 #'
 #' Applies custom function on running windows.
-#' @param x (`vector`, `data.frame`, `matrix`, `xts`)\cr
+#' @param x (`vector`, `data.frame`, `matrix`, `xts`, `grouped_df`)\cr
 #'  Input in runner custom function `f`.
 #'
 #' @param k (`integer` vector or single value)\cr
@@ -42,9 +42,6 @@
 #'  Whether incomplete window should return `NA` (if `na_pad = TRUE`)
 #'  Incomplete window is when some parts of the window are out of range.
 #'
-#' @param type (defunct)\cr
-#'  argument defunct from version 0.4.0. Use `simplify` instead.
-#'
 #' @param simplify (`logical` or `character` value)\cr
 #'  should the result be simplified to a vector, matrix or higher dimensional
 #'  array if possible. The default value, `simplify = TRUE`, returns a vector or
@@ -56,7 +53,6 @@
 #' @param cl (`cluster`) *experimental*\cr
 #'  Create and pass the cluster to the `runner` function to run each window
 #'  calculation in parallel. See \code{\link[parallel]{makeCluster}} in details.
-#'
 #'
 #' @param ... (optional)\cr
 #'   other arguments passed to the function `f`.
@@ -149,18 +145,10 @@ runner <- function(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
   ) {
-  if (!missing(type)) {
-    warning(
-      "Argument 'type' is defunct and will be completely removed in the next release. #nolint
-      Please use 'simplify' argument to manage the output type."
-    )
-  }
-
   UseMethod("runner", x)
 }
 
@@ -235,7 +223,6 @@ runner.default <- function(  #nolint
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -339,7 +326,6 @@ runner.data.frame <- function( #nolint
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -419,7 +405,6 @@ runner.grouped_df <- function(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -460,7 +445,6 @@ runner.matrix <- function(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -534,7 +518,6 @@ runner.xts <- function(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...

--- a/inst/tinytest/test_external_compatibility.R
+++ b/inst/tinytest/test_external_compatibility.R
@@ -61,7 +61,7 @@ expect_true(
   all(res$m == 20)
 )
 
-# running on grouped_df index set -----
+# running on grouped_df index set ------
 res <- data %>%
   dplyr::group_by(group1, group2) %>%
   run_by(idx = "index") %>%

--- a/inst/tinytest/test_external_compatibility.R
+++ b/inst/tinytest/test_external_compatibility.R
@@ -125,7 +125,7 @@ expect_equal(
 grouped_dplyr <- data %>%
   dplyr::group_by(group1, group2) %>%
   dplyr::mutate(
-    xx = runner(
+    xx = runner.grouped_df(
       x = .,
       f = function(df) {
         paste(df$x, collapse = " ")
@@ -139,7 +139,7 @@ grouped_dplyr2 <- data %>%
   dplyr::group_by(group1, group2) %>%
   run_by(idx = "index") %>%
   dplyr::mutate(
-    xx = runner(
+    xx = runner.grouped_df(
       x = .,
       f = function(df) {
         paste(df$x, collapse = " ")
@@ -147,7 +147,6 @@ grouped_dplyr2 <- data %>%
       k = 2
     )
   )
-
 
 expected <- unlist(
   use.names = FALSE,

--- a/inst/tinytest/test_external_compatibility.R
+++ b/inst/tinytest/test_external_compatibility.R
@@ -83,3 +83,18 @@ expect_equal(
   grouped_dplyr$xx,
   paste(data$group1, data$group2)
 )
+
+# running on columns without run_by
+grouped_dplyr <- data %>%
+  dplyr::group_by(group1, group2) %>%
+  dplyr::mutate(
+    xx = runner(
+      x = unique(paste(group1, group2)),
+      f = paste, collapse = ""),
+      idx = "index"
+  )
+
+expect_equal(
+  grouped_dplyr$xx,
+  paste(data$group1, data$group2)
+)

--- a/inst/tinytest/test_external_compatibility.R
+++ b/inst/tinytest/test_external_compatibility.R
@@ -42,8 +42,6 @@ expect_identical(
   "index"
 )
 
-
-# correct grouping results ------
 data <- data.frame(
   index = c(2, 5, 5, 7, 10, 12, 12, 12, 15, 16, 19,
             20, 20, 21, 23, 23, 25, 27, 27, 28),
@@ -52,49 +50,128 @@ data <- data.frame(
   x = 1:20
 )
 
-# running on grouped_df
+# single column in mutate is grouped ------
+res <- data %>%
+  group_by(group1) %>%
+  mutate(
+    m = length(x)
+  )
+
+expect_true(
+  all(res$m == 20)
+)
+
+# running on grouped_df index set -----
 res <- data %>%
   dplyr::group_by(group1, group2) %>%
   run_by(idx = "index") %>%
   dplyr::mutate(
-    x = runner(
+    xx = runner(
       .,
-      f = function(x) {
-        unique(paste(x$group1, x$group2))
+      f = function(df) {
+        paste(df$x, collapse = " ")
       }
     )
   )
-expect_identical(
-  res$x,
-  paste(data$group1, data$group2)
+
+expected <- unlist(
+  use.names = FALSE,
+  tapply(
+    data$x,
+    paste(data$group1, data$group2),
+    runner,
+    f = paste,
+    collapse = " "
+  )
 )
 
-# running on columns from grouped_df
+expect_identical(
+  res$xx,
+  expected
+)
+
+
+# running on columns from grouped_df k without idx -----
 grouped_dplyr <- data %>%
+  dplyr::group_by(group1, group2) %>%
+  dplyr::mutate(
+    xx = runner(
+      x = .,
+      f = function(df) {
+        paste(df$x, collapse = " ")
+      },
+      k = 2
+    )
+  )
+
+expected <- unlist(
+  use.names = FALSE,
+  tapply(
+    data$x,
+    paste(data$group1, data$group2),
+    runner,
+    f = paste,
+    collapse = " ",
+    k = 2
+  )
+)
+
+expect_equal(
+  grouped_dplyr$xx,
+  expected
+)
+
+# running on columns from grouped_df k with idx -----
+grouped_dplyr <- data %>%
+  dplyr::group_by(group1, group2) %>%
+  dplyr::mutate(
+    xx = runner(
+      x = .,
+      f = function(df) {
+        paste(df$x, collapse = " ")
+      },
+      k = 2,
+      idx = index
+    )
+  )
+
+grouped_dplyr2 <- data %>%
   dplyr::group_by(group1, group2) %>%
   run_by(idx = "index") %>%
   dplyr::mutate(
     xx = runner(
-      x = unique(paste(group1, group2)),
-      f = paste, collapse = "")
+      x = .,
+      f = function(df) {
+        paste(df$x, collapse = " ")
+      },
+      k = 2
+    )
   )
 
-expect_equal(
-  grouped_dplyr$xx,
-  paste(data$group1, data$group2)
+
+expected <- unlist(
+  use.names = FALSE,
+  tapply(
+    1:40,
+    paste(data$group1, data$group2),
+    function(idx) {
+      runner(
+        data$x[idx],
+        f = paste,
+        collapse = " ",
+        k = 2,
+        idx = data$index[idx]
+      )
+    }
+  )
 )
 
-# running on columns without run_by
-grouped_dplyr <- data %>%
-  dplyr::group_by(group1, group2) %>%
-  dplyr::mutate(
-    xx = runner(
-      x = unique(paste(group1, group2)),
-      f = paste, collapse = ""),
-      idx = "index"
-  )
-
 expect_equal(
   grouped_dplyr$xx,
-  paste(data$group1, data$group2)
+  expected
+)
+
+expect_equal(
+  grouped_dplyr2$xx,
+  expected
 )

--- a/inst/tinytest/test_runner.R
+++ b/inst/tinytest/test_runner.R
@@ -1347,12 +1347,3 @@ expect_error(
   runner(1:10, lag = rep(5, 10), idx = 1:10, at = c(4, 5), f = mean),
   "length\\(lag\\) should be 1 or equal to"
 )
-
-#Test defunct -------
-expect_warning(
-  runner(
-    1:10,
-    f = function(x) x,
-    type = "numeric"
-  )
-)

--- a/man/fill_run.Rd
+++ b/man/fill_run.Rd
@@ -7,7 +7,7 @@
 fill_run(x, run_for_first = FALSE, only_within = FALSE)
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{run_for_first}{If first elements are filled with \code{NA}, \code{run_for_first = TRUE}

--- a/man/lag_run.Rd
+++ b/man/lag_run.Rd
@@ -7,7 +7,7 @@
 lag_run(x, lag = 1L, idx = integer(0), nearest = FALSE)
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{lag}{(\code{integer} vector or single value)\cr

--- a/man/max_run.Rd
+++ b/man/max_run.Rd
@@ -15,7 +15,7 @@ max_run(
 )
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{k}{(\code{integer} vector or single value)\cr

--- a/man/min_run.Rd
+++ b/man/min_run.Rd
@@ -15,7 +15,7 @@ min_run(
 )
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{k}{(\code{integer} vector or single value)\cr

--- a/man/minmax_run.Rd
+++ b/man/minmax_run.Rd
@@ -7,7 +7,7 @@
 minmax_run(x, metric = "min", na_rm = TRUE)
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{metric}{\code{character} what to return, minimum or maximum}

--- a/man/run_by.Rd
+++ b/man/run_by.Rd
@@ -7,7 +7,7 @@
 run_by(x, idx, k, lag, na_pad, at)
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{idx}{(\code{integer}, \code{Date}, \code{POSIXt})\cr

--- a/man/runner.Rd
+++ b/man/runner.Rd
@@ -17,7 +17,6 @@ runner(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -31,7 +30,6 @@ runner(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -45,7 +43,6 @@ runner(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -59,7 +56,6 @@ runner(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -73,7 +69,6 @@ runner(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
@@ -87,14 +82,13 @@ runner(
   idx = integer(0),
   at = integer(0),
   na_pad = FALSE,
-  type,
   simplify = TRUE,
   cl = NULL,
   ...
 )
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{f}{(\code{function})\cr
@@ -134,9 +128,6 @@ See 'Specifying time-intervals' in details section.}
 \item{na_pad}{(\code{logical} single value)\cr
 Whether incomplete window should return \code{NA} (if \code{na_pad = TRUE})
 Incomplete window is when some parts of the window are out of range.}
-
-\item{type}{(defunct)\cr
-argument defunct from version 0.4.0. Use \code{simplify} instead.}
 
 \item{simplify}{(\code{logical} or \code{character} value)\cr
 should the result be simplified to a vector, matrix or higher dimensional

--- a/man/which_run.Rd
+++ b/man/which_run.Rd
@@ -16,7 +16,7 @@ which_run(
 )
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{k}{(\code{integer} vector or single value)\cr

--- a/man/window_run.Rd
+++ b/man/window_run.Rd
@@ -14,7 +14,7 @@ window_run(
 )
 }
 \arguments{
-\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts})\cr
+\item{x}{(\code{vector}, \code{data.frame}, \code{matrix}, \code{xts}, \code{grouped_df})\cr
 Input in runner custom function \code{f}.}
 
 \item{k}{(\code{integer} vector or single value)\cr

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // fill_run
 SEXP fill_run(SEXP x, bool run_for_first, bool only_within);
 RcppExport SEXP _runner_fill_run(SEXP xSEXP, SEXP run_for_firstSEXP, SEXP only_withinSEXP) {


### PR DESCRIPTION
Fixes the missing `k` argument for `grouped_df`

```r
remotes::install_github("gogonzo/runner", ref = "79_fix_grouped_df")
```

```r
library(runner)
library(dplyr)
x <- cumsum(rnorm(20))
y <- 3 * x + rnorm(20)
date <- Sys.Date() + cumsum(sample(1:3, 20, replace = TRUE)) # unequaly spaced time series
group <- rep(c("a", "b"), each = 10)

data.frame(date, group, y, x) %>%
  group_by(group) %>%
  #run_by(idx = "date", k = "5 days") %>%
  mutate(
    alpha_5 = runner(
      x = ., idx = "date", k = "5 days",
      f = function(x) {
        print(nrow(x))
        coefficients(lm(x ~ y, x))[1]
      }
    ),
    beta_5 = runner(
      x = ., idx = "date", k = "5 days",
      f = function(x) {
        print(nrow(x))
        coefficients(lm(x ~ y, x))[1]
      }
    )
  )

```