### PR TITLE
docs: fix roxygen typos in fill_run, sum_run, max_run, which_run

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -7,15 +7,14 @@
 #' @inheritParams runner
 #' @param run_for_first If first elements are filled with `NA`, `run_for_first = TRUE`
 #' allows to fill all initial `NA` with nearest non-NA value. By default
-#' `run_for_first = TRUE`
+#' `run_for_first = FALSE`.
 #' @param only_within `NA` are replaced only if previous and next non-NA
-#' values are the same. By default `only_within = TRUE`
+#' values are the same. By default `only_within = FALSE`.
 #' @return vector - `x` containing all `x` elements with `NA`
 #' replaced with previous non-NA element.
 #' @examples
-#' fill_run(c(NA, NA,1:10, NA, NA), run_for_first = TRUE)
-#' fill_run(c(NA, NA,1:10, NA, NA), run_for_first = TRUE)
-#' fill_run(c(NA, NA,1:10, NA, NA), run_for_first = FALSE)
+#' fill_run(c(NA, NA, 1:10, NA, NA), run_for_first = TRUE)
+#' fill_run(c(NA, NA, 1:10, NA, NA), run_for_first = FALSE)
 #' fill_run(c(NA, NA, 1, 2, NA, NA, 2, 2, NA, NA, 1, NA, NA), run_for_first = TRUE, only_within = TRUE)
 #' @export
 fill_run <- function(x, run_for_first = FALSE, only_within = FALSE) {
@@ -100,7 +99,7 @@ minmax_run <- function(x, metric = "min", na_rm = TRUE) {
 #'
 #' @inheritParams runner
 #'
-#' @return sum `code` vector of length equals length of `x`.
+#' @return sum (`numeric`) vector of length equals length of `x`.
 #' @examples
 #' set.seed(11)
 #' x1 <- rnorm(15)
@@ -138,7 +137,7 @@ mean_run <- function(x, k = integer(0), lag = integer(1), idx = integer(0), at =
 #' Running maximum
 #'
 #'
-#' `min_run` calculates running max on given `x` numeric vector,
+#' `max_run` calculates running max on given `x` numeric vector,
 #' specified `k` window size.
 #' @inheritParams runner
 #' @inheritParams sum_run
@@ -203,7 +202,7 @@ streak_run <- function(x, k = integer(0), lag = integer(1), idx = integer(0), at
 #' Running which
 #'
 #'
-#' `min_run` calculates running which - returns index of element where `x == TRUE`.
+#' `which_run` calculates running which - returns index of element where `x == TRUE`.
 #' @inheritParams runner
 #' @inheritParams sum_run
 #' @param which `character` value "first" or "last" denoting if the first or last `TRUE`

--- a/man/fill_run.Rd
+++ b/man/fill_run.Rd
@@ -12,10 +12,10 @@ input data.}
 
 \item{run_for_first}{If first elements are filled with \code{NA}, \code{run_for_first = TRUE}
 allows to fill all initial \code{NA} with nearest non-NA value. By default
-\code{run_for_first = TRUE}}
+\code{run_for_first = FALSE}.}
 
 \item{only_within}{\code{NA} are replaced only if previous and next non-NA
-values are the same. By default \code{only_within = TRUE}}
+values are the same. By default \code{only_within = FALSE}.}
 }
 \value{
 vector - \code{x} containing all \code{x} elements with \code{NA}
@@ -25,8 +25,7 @@ replaced with previous non-NA element.
 Fill \code{NA} with last non-NA element.
 }
 \examples{
-fill_run(c(NA, NA,1:10, NA, NA), run_for_first = TRUE)
-fill_run(c(NA, NA,1:10, NA, NA), run_for_first = TRUE)
-fill_run(c(NA, NA,1:10, NA, NA), run_for_first = FALSE)
+fill_run(c(NA, NA, 1:10, NA, NA), run_for_first = TRUE)
+fill_run(c(NA, NA, 1:10, NA, NA), run_for_first = FALSE)
 fill_run(c(NA, NA, 1, 2, NA, NA, 2, 2, NA, NA, 1, NA, NA), run_for_first = TRUE, only_within = TRUE)
 }

--- a/man/max_run.Rd
+++ b/man/max_run.Rd
@@ -45,7 +45,7 @@ If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}
 max (\code{numeric}) vector of length equals length of \code{x}.
 }
 \description{
-\code{min_run} calculates running max on given \code{x} numeric vector,
+\code{max_run} calculates running max on given \code{x} numeric vector,
 specified \code{k} window size.
 }
 \examples{

--- a/man/runner.Rd
+++ b/man/runner.Rd
@@ -115,7 +115,7 @@ generates a regular sequence over the range of \code{idx}.}
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}
 
 \item{simplify}{(\code{logical} or \code{character})\cr
-Simplify result like \code{\link[base:lapply]{base::sapply()}}. \code{TRUE} returns vector/matrix,
+Simplify result like \code{\link[base:sapply]{base::sapply()}}. \code{TRUE} returns vector/matrix,
 \code{"array"} may return a higher-dimensional array.}
 
 \item{cl}{(\code{cluster}) \emph{experimental}\cr
@@ -276,7 +276,7 @@ and shifts at each position.
 
 Pass a \code{\link[parallel:makeCluster]{parallel::makeCluster()}} object via \code{cl} to run windows in
 parallel. Objects referenced inside \code{f} (other than its arguments) must
-be exported with \code{\link[parallel:clusterApply]{parallel::clusterExport()}} beforehand. Parallel
+be exported with \code{\link[parallel:clusterExport]{parallel::clusterExport()}} beforehand. Parallel
 execution adds overhead and is only beneficial for expensive computations.
 }
 }

--- a/man/sum_run.Rd
+++ b/man/sum_run.Rd
@@ -42,7 +42,7 @@ if \code{TRUE} sum is calculating excluding \code{NA}.}
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}
 }
 \value{
-sum \code{code} vector of length equals length of \code{x}.
+sum (\code{numeric}) vector of length equals length of \code{x}.
 }
 \description{
 Running sum in specified window of numeric vector.

--- a/man/which_run.Rd
+++ b/man/which_run.Rd
@@ -49,7 +49,7 @@ If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}
 integer vector of indexes of the same length as \code{x}.
 }
 \description{
-\code{min_run} calculates running which - returns index of element where \code{x == TRUE}.
+\code{which_run} calculates running which - returns index of element where \code{x == TRUE}.
 }
 \examples{
 set.seed(11)

--- a/src/fill_run.cpp
+++ b/src/fill_run.cpp
@@ -8,15 +8,14 @@ using namespace Rcpp;
 //' @inheritParams runner
 //' @param run_for_first If first elements are filled with `NA`, `run_for_first = TRUE`
 //' allows to fill all initial `NA` with nearest non-NA value. By default
-//' `run_for_first = TRUE`
+//' `run_for_first = FALSE`.
 //' @param only_within `NA` are replaced only if previous and next non-NA
-//' values are the same. By default `only_within = TRUE`
+//' values are the same. By default `only_within = FALSE`.
 //' @return vector - `x` containing all `x` elements with `NA`
 //' replaced with previous non-NA element.
 //' @examples
-//' fill_run(c(NA, NA,1:10, NA, NA), run_for_first = TRUE)
-//' fill_run(c(NA, NA,1:10, NA, NA), run_for_first = TRUE)
-//' fill_run(c(NA, NA,1:10, NA, NA), run_for_first = FALSE)
+//' fill_run(c(NA, NA, 1:10, NA, NA), run_for_first = TRUE)
+//' fill_run(c(NA, NA, 1:10, NA, NA), run_for_first = FALSE)
 //' fill_run(c(NA, NA, 1, 2, NA, NA, 2, 2, NA, NA, 1, NA, NA), run_for_first = TRUE, only_within = TRUE)
 //' @export
 // [[Rcpp::export]]

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -805,7 +805,7 @@ runner_vec(Rcpp::Vector<ITYPE> const &x,
 //'
 //' @inheritParams runner
 //'
-//' @return sum `code` vector of length equals length of `x`.
+//' @return sum (`numeric`) vector of length equals length of `x`.
 //' @examples
 //' set.seed(11)
 //' x1 <- rnorm(15)
@@ -990,7 +990,7 @@ NumericVector mean_run(
 //' Running maximum
 //'
 //'
-//' `min_run` calculates running max on given `x` numeric vector,
+//' `max_run` calculates running max on given `x` numeric vector,
 //' specified `k` window size.
 //' @inheritParams runner
 //' @inheritParams sum_run
@@ -1156,7 +1156,7 @@ IntegerVector streak_run(
 //' Running which
 //'
 //'
-//' `min_run` calculates running which - returns index of element where `x == TRUE`.
+//' `which_run` calculates running which - returns index of element where `x == TRUE`.
 //' @inheritParams runner
 //' @inheritParams sum_run
 //' @param which `character` value "first" or "last" denoting if the first or last `TRUE`


### PR DESCRIPTION
## Summary

Fixes several documentation bugs in roxygen comments across C++ source files:

### fill_run (src/fill_run.cpp)
- **Default values documented incorrectly**: `run_for_first` and `only_within` were both documented as defaulting to `TRUE`, but the actual C++ defaults are `FALSE`. Users relying on the docs would get unexpected behavior.
- **Duplicate example line**: Removed redundant example line.

### sum_run (src/runner.cpp)
- **@return typo**: `code` replaced with `numeric`

### max_run (src/runner.cpp)
- **Wrong function name in description**: `min_run` replaced with `max_run`

### which_run (src/runner.cpp)
- **Wrong function name in description**: `min_run` replaced with `which_run`

## Validation

- All tinytest tests pass (fill_run: 7, sum_run: 94, max_run: 61, which_run: 51, runner: 189)
- Rd files regenerated with roxygen2
- Changes verified against C++ source defaults

## Files changed

| File | Change |
|------|--------|
| src/fill_run.cpp | Fix default value docs, remove duplicate example |
| src/runner.cpp | Fix sum_run @return typo, max_run/which_run descriptions |
| R/RcppExports.R | Auto-regenerated by roxygen2 |
| man/fill_run.Rd | Auto-regenerated by roxygen2 |
| man/max_run.Rd | Auto-regenerated by roxygen2 |
| man/sum_run.Rd | Auto-regenerated by roxygen2 |
| man/which_run.Rd | Auto-regenerated by roxygen2 |
