### PR TITLE
docs: add grouped rolling mean example to runner.Rd

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -460,6 +460,21 @@ runner.data.frame <- function(
 }
 
 #' @rdname runner
+#' @examples
+#'
+#' # Panel data: rolling mean within groups
+#' # (equivalent to Stata's: bysort firm (year): rolling mean(x), window(3)
+#' library(dplyr)
+#' df <- data.frame(
+#'   firm = rep(c("A", "B"), each = 5),
+#'   year = rep(2010:2014, 2),
+#'   sales = c(100, 110, 125, 130, 145, 200, 215, 230, 250, 270)
+#' )
+#' df %>%
+#'   arrange(firm, year) %>%
+#'   group_by(firm) %>%
+#'   mutate(roll_mean = runner(sales, f = mean, k = 3)) %>%
+#'   ungroup()
 #' @export
 runner.grouped_df <- function(
   x,

--- a/man/runner.Rd
+++ b/man/runner.Rd
@@ -115,7 +115,7 @@ generates a regular sequence over the range of \code{idx}.}
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}
 
 \item{simplify}{(\code{logical} or \code{character})\cr
-Simplify result like \code{\link[base:lapply]{base::sapply()}}. \code{TRUE} returns vector/matrix,
+Simplify result like \code{\link[base:sapply]{base::sapply()}}. \code{TRUE} returns vector/matrix,
 \code{"array"} may return a higher-dimensional array.}
 
 \item{cl}{(\code{cluster}) \emph{experimental}\cr
@@ -276,7 +276,7 @@ and shifts at each position.
 
 Pass a \code{\link[parallel:makeCluster]{parallel::makeCluster()}} object via \code{cl} to run windows in
 parallel. Objects referenced inside \code{f} (other than its arguments) must
-be exported with \code{\link[parallel:clusterApply]{parallel::clusterExport()}} beforehand. Parallel
+be exported with \code{\link[parallel:clusterExport]{parallel::clusterExport()}} beforehand. Parallel
 execution adds overhead and is only beneficial for expensive computations.
 }
 }
@@ -380,6 +380,20 @@ runner(
   cl = cl
 )
 stopCluster(cl)
+
+# Panel data: rolling mean within groups
+# (equivalent to Stata's: bysort firm (year): rolling mean(x), window(3)
+library(dplyr)
+df <- data.frame(
+  firm = rep(c("A", "B"), each = 5),
+  year = rep(2010:2014, 2),
+  sales = c(100, 110, 125, 130, 145, 200, 215, 230, 250, 270)
+)
+df \%>\%
+  arrange(firm, year) \%>\%
+  group_by(firm) \%>\%
+  mutate(roll_mean = runner(sales, f = mean, k = 3)) \%>\%
+  ungroup()
 
 # runner with matrix
 data <- matrix(data = runif(100, 0, 1), nrow = 20, ncol = 5)


### PR DESCRIPTION
## Summary

Added a panel data example to the `runner.grouped_df` method in `runner.Rd` showing how to compute rolling means within groups using dplyr.

**Stata equivalent:**
```stata
bysort firm (year): rolling mean_sales = r(mean), window(3) clear: summarize sales
```

**runner equivalent (new example):**
```r
library(dplyr)
df <- data.frame(
  firm = rep(c(A, B), each = 5),
  year = rep(2010:2014, 2),
  sales = c(100, 110, 125, 130, 145, 200, 215, 230, 250, 270)
)
df %>%
  arrange(firm, year) %>%
  group_by(firm) %>%
  mutate(roll_mean = runner(sales, f = mean, k = 3)) %>%
  ungroup()
```

## Rationale

The `runner.grouped_df` method had no examples. Rolling operations within groups (panel data) is the single most common migration scenario from Stata, where `bysort` + `rolling` automatically handles group boundaries. The `runner()` function with dplyr's `group_by` provides the equivalent functionality.

## Validation

- `tools::checkRd('man/runner.Rd')` passes (no output = no errors)
- All 1043 tinytest tests pass
- 2 files changed, 31 lines added