### PR TITLE
docs: fix na_rm param description inherited by all *_run functions

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -96,7 +96,7 @@ minmax_run <- function(x, metric = "min", na_rm = TRUE) {
 #'  vector defines the indexes which data is computed at.
 #'
 #' @param na_rm `logical` single value (default `na_rm = TRUE`) -
-#' if `TRUE` sum is calculating excluding `NA`.
+#' if `TRUE`, missing values are removed before calculation.
 #'
 #' @inheritParams runner
 #'

--- a/man/max_run.Rd
+++ b/man/max_run.Rd
@@ -36,7 +36,7 @@ instead of \code{length(x)}. A single time-interval string (e.g. \code{"month"})
 generates a regular sequence over the range of \code{idx}.}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 
 \item{na_pad}{(\code{logical})\cr
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}

--- a/man/mean_run.Rd
+++ b/man/mean_run.Rd
@@ -36,7 +36,7 @@ Vector of any size and any value defining output data points. Values of the
 vector defines the indexes which data is computed at.}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 
 \item{na_pad}{(\code{logical})\cr
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}

--- a/man/min_run.Rd
+++ b/man/min_run.Rd
@@ -36,7 +36,7 @@ instead of \code{length(x)}. A single time-interval string (e.g. \code{"month"})
 generates a regular sequence over the range of \code{idx}.}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 
 \item{na_pad}{(\code{logical})\cr
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}

--- a/man/minmax_run.Rd
+++ b/man/minmax_run.Rd
@@ -13,7 +13,7 @@ input data.}
 \item{metric}{\code{character} what to return, minimum or maximum}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 }
 \value{
 list.

--- a/man/runner.Rd
+++ b/man/runner.Rd
@@ -115,7 +115,7 @@ generates a regular sequence over the range of \code{idx}.}
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}
 
 \item{simplify}{(\code{logical} or \code{character})\cr
-Simplify result like \code{\link[base:lapply]{base::sapply()}}. \code{TRUE} returns vector/matrix,
+Simplify result like \code{\link[base:sapply]{base::sapply()}}. \code{TRUE} returns vector/matrix,
 \code{"array"} may return a higher-dimensional array.}
 
 \item{cl}{(\code{cluster}) \emph{experimental}\cr
@@ -276,7 +276,7 @@ and shifts at each position.
 
 Pass a \code{\link[parallel:makeCluster]{parallel::makeCluster()}} object via \code{cl} to run windows in
 parallel. Objects referenced inside \code{f} (other than its arguments) must
-be exported with \code{\link[parallel:clusterApply]{parallel::clusterExport()}} beforehand. Parallel
+be exported with \code{\link[parallel:clusterExport]{parallel::clusterExport()}} beforehand. Parallel
 execution adds overhead and is only beneficial for expensive computations.
 }
 }

--- a/man/streak_run.Rd
+++ b/man/streak_run.Rd
@@ -35,7 +35,7 @@ instead of \code{length(x)}. A single time-interval string (e.g. \code{"month"})
 generates a regular sequence over the range of \code{idx}.}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 
 \item{na_pad}{(\code{logical})\cr
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}

--- a/man/sum_run.Rd
+++ b/man/sum_run.Rd
@@ -36,7 +36,7 @@ Vector of any size and any value defining output data points. Values of the
 vector defines the indexes which data is computed at.}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 
 \item{na_pad}{(\code{logical})\cr
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}

--- a/man/which_run.Rd
+++ b/man/which_run.Rd
@@ -40,7 +40,7 @@ generates a regular sequence over the range of \code{idx}.}
 index is returned from the window.}
 
 \item{na_rm}{\code{logical} single value (default \code{na_rm = TRUE}) -
-if \code{TRUE} sum is calculating excluding \code{NA}.}
+if \code{TRUE}, missing values are removed before calculation.}
 
 \item{na_pad}{(\code{logical})\cr
 If \code{TRUE}, return \code{NA} for windows that extend beyond the data range.}


### PR DESCRIPTION
## Summary

The `na_rm` parameter description in `sum_run.Rd` says "sum is calculating excluding NA", but this description is inherited via `@inheritParams sum_run` by **all** other `*_run` functions — making it wrong for , , , , , and .

### Before (all 7 functions)
> if `TRUE` sum is calculating excluding `NA`.

### After (all 7 functions)
> if `TRUE`, missing values are removed before calculation.

## Validation

- `tools::checkRd()` passes for all affected Rd files
- All 1043 tinytest tests pass
- 1 file changed in source (R/RcppExports.R), 8 auto-generated Rd files updated

## Files Changed

| File | Change |
|------|--------|
| R/RcppExports.R | Fix na_rm description in sum_run roxygen |
| man/sum_run.Rd | Auto-regenerated |
| man/mean_run.Rd | Auto-regenerated |
| man/max_run.Rd | Auto-regenerated |
| man/min_run.Rd | Auto-regenerated |
| man/streak_run.Rd | Auto-regenerated |
| man/which_run.Rd | Auto-regenerated |
| man/minmax_run.Rd | Auto-regenerated |
| man/runner.Rd | Auto-regenerated |

## Duplicate Check

- PR #109 fixes different issues (fill_run defaults, sum_run @return, max_run/which_run wrong function names) but does NOT fix the na_rm inheritance
- This is a separate, complementary fix