### PR TITLE
docs: fix minmax_run description and subtracted typo

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -56,8 +56,7 @@ length_run <- function(k = integer(1), lag = integer(1), idx = integer(0)) {
 #' Running min/max
 #'
 #'
-#' `min_run` calculates running minimum-maximum on given `x` numeric
-#'  vector, specified `k` window size.
+#' `minmax_run` calculates running minimum or maximum on given `x` numeric vector.
 #' @inheritParams runner
 #' @inheritParams sum_run
 #' @param metric `character` what to return, minimum or maximum

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,7 +98,7 @@
 #' Formats time-unit-interval to valid for runner
 #'
 #' Formats time-unit-interval to valid for runner. User specifies `k` as
-#' positive number but this means that this interval needs to be substracted
+#' positive number but this means that this interval needs to be subtracted
 #' from `idx` - because windows length extends window backwards in time.
 #' The same situation for lag.
 #' @param k (k or lag) object from runner to be formatted

--- a/man/dot-reformat_k.Rd
+++ b/man/dot-reformat_k.Rd
@@ -14,7 +14,7 @@ for \code{lag} is \code{FALSE}}
 }
 \description{
 Formats time-unit-interval to valid for runner. User specifies \code{k} as
-positive number but this means that this interval needs to be substracted
+positive number but this means that this interval needs to be subtracted
 from \code{idx} - because windows length extends window backwards in time.
 The same situation for lag.
 }

--- a/man/minmax_run.Rd
+++ b/man/minmax_run.Rd
@@ -19,6 +19,5 @@ if \code{TRUE} sum is calculating excluding \code{NA}.}
 list.
 }
 \description{
-\code{min_run} calculates running minimum-maximum on given \code{x} numeric
-vector, specified \code{k} window size.
+\code{minmax_run} calculates running minimum or maximum on given \code{x} numeric vector.
 }

--- a/src/minmax_run.cpp
+++ b/src/minmax_run.cpp
@@ -3,8 +3,7 @@
 //' Running min/max
 //'
 //'
-//' `min_run` calculates running minimum-maximum on given `x` numeric
-//'  vector, specified `k` window size.
+//' `minmax_run` calculates running minimum or maximum on given `x` numeric vector.
 //' @inheritParams runner
 //' @inheritParams sum_run
 //' @param metric `character` what to return, minimum or maximum


### PR DESCRIPTION
## Summary

Fixes two documentation issues in runner package:

1. **minmax_run.Rd**: Description incorrectly referenced `min_run` instead of `minmax_run`, and mentioned "specified `k` window size" despite `minmax_run` having no `k` parameter.

2. **dot-reformat_k.Rd** (from `R/utils.R`): Typo "substracted" → "subtracted".

## Changes

| File | Change |
|------|--------|
| `src/minmax_run.cpp` | Fix roxygen comment: `min_run` → `minmax_run`, remove `k` reference |
| `R/RcppExports.R` | Auto-regenerated from C++ source |
| `R/utils.R` | Fix "substracted" → "subtracted" typo |
| `man/minmax_run.Rd` | Regenerated |
| `man/dot-reformat_k.Rd` | Regenerated |

## Validation

- `tools::checkRd("man/minmax_run.Rd")` — passes
- `tools::checkRd("man/dot-reformat_k.Rd")` — passes
- `R CMD build .` — succeeds
- `R CMD check runner_0.5.0.tar.gz --no-manual` — Status: 1 WARNING (pre-existing dplyr undeclared), 1 NOTE (pre-existing .claude hidden dir), both unrelated to this change
- All examples run correctly

## Related

- PR #109 fixed `max_run` and `which_run` descriptions but missed `minmax_run`
- PR #112 addresses `na_rm` param description but not this issue