### PR TITLE
docs: fix missing closing parenthesis in Stata comment in runner.Rd

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -463,7 +463,7 @@ runner.data.frame <- function(
 #' @examples
 #'
 #' # Panel data: rolling mean within groups
-#' # (equivalent to Stata's: bysort firm (year): rolling mean(x), window(3)
+#' # (equivalent to Stata's: bysort firm (year): rolling mean(x), window(3))
 #' library(dplyr)
 #' df <- data.frame(
 #'   firm = rep(c("A", "B"), each = 5),

--- a/man/runner.Rd
+++ b/man/runner.Rd
@@ -382,7 +382,7 @@ runner(
 stopCluster(cl)
 
 # Panel data: rolling mean within groups
-# (equivalent to Stata's: bysort firm (year): rolling mean(x), window(3)
+# (equivalent to Stata's: bysort firm (year): rolling mean(x), window(3))
 library(dplyr)
 df <- data.frame(
   firm = rep(c("A", "B"), each = 5),


### PR DESCRIPTION
Fix the Stata equivalence comment in the panel data example where a closing parenthesis was missing. The comment now correctly reads:
`(equivalent to Stata's: bysort firm (year): rolling mean(x), window(3))`

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| R/run.R | 1 | Documentation (roxygen source) |
| man/runner.Rd | 1 | Documentation (generated) |

## Validation

- `roxygen2::roxygenize()` — regenerates Rd successfully
- `tools::checkRd('man/runner.Rd')` — passes (no output = no errors)
- Change is purely documentation (no code changes)

## Stata Migration Relevance

This fix improves the Stata equivalence comment in the panel data example, which is directly useful for Stata migrants learning how to use `runner()` for rolling window operations within groups.