### PR TITLE
docs: fix bare infinitive 'allows to fill' in fill_run.Rd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Suggests:
   knitr,
   rmarkdown,
   tinytest
-RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -6,7 +6,7 @@
 #' Fill `NA` with last non-NA element.
 #' @inheritParams runner
 #' @param run_for_first If first elements are filled with `NA`, `run_for_first = TRUE`
-#' allows to fill all initial `NA` with nearest non-NA value. By default
+#' allows filling all initial `NA` with nearest non-NA value. By default
 #' `run_for_first = FALSE`.
 #' @param only_within `NA` are replaced only if previous and next non-NA
 #' values are the same. By default `only_within = FALSE`.

--- a/man/fill_run.Rd
+++ b/man/fill_run.Rd
@@ -11,7 +11,7 @@ fill_run(x, run_for_first = FALSE, only_within = FALSE)
 input data.}
 
 \item{run_for_first}{If first elements are filled with \code{NA}, \code{run_for_first = TRUE}
-allows to fill all initial \code{NA} with nearest non-NA value. By default
+allows filling all initial \code{NA} with nearest non-NA value. By default
 \code{run_for_first = FALSE}.}
 
 \item{only_within}{\code{NA} are replaced only if previous and next non-NA

--- a/src/fill_run.cpp
+++ b/src/fill_run.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 //' Fill `NA` with last non-NA element.
 //' @inheritParams runner
 //' @param run_for_first If first elements are filled with `NA`, `run_for_first = TRUE`
-//' allows to fill all initial `NA` with nearest non-NA value. By default
+//' allows filling all initial `NA` with nearest non-NA value. By default
 //' `run_for_first = FALSE`.
 //' @param only_within `NA` are replaced only if previous and next non-NA
 //' values are the same. By default `only_within = FALSE`.


### PR DESCRIPTION
## Summary

Fixed bare infinitive grammatical error "allows to fill" in the `@param run_for_first` description of `fill_run()`.

## Problem

The verb "allow" requires a gerund (allow + -ing) or a noun phrase before "to" (allow + someone + to). The current documentation states:

> `run_for_first = TRUE` allows to fill all initial `NA` with nearest non-NA value.

This is a bare infinitive error.

## Fix

Changed "allows to fill" to "allows filling":

> `run_for_first = TRUE` allows filling all initial `NA` with nearest non-NA value.

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| src/fill_run.cpp | 1 | Documentation (roxygen source) |
| R/RcppExports.R | 1 | Documentation (generated) |
| man/fill_run.Rd | 1 | Documentation (generated) |
| DESCRIPTION | 1 | roxygen2 version update |
| **Total** | **4** | |

## Validation

- `tools::checkRd('man/fill_run.Rd')` — passes (no output = no errors)
- `R CMD check --no-manual --no-tests --no-vignettes --no-examples` — Status: OK (pre-existing WARNING about unstated dplyr dependency in examples, unrelated to this change)
- Change is purely documentation (no code changes)

## Duplicate Check

- No existing branch or PR addresses bare infinitive in fill_run.Rd
- PR #115 fixes Stata comment parenthesis in runner.Rd (different file)
- PR #114 fixes minmax_run description (different file)
- PR #113 fixes @param k Rd syntax (different file)
- PR #112 fixes na_rm param description (different file)
- PR #110 adds panel data example to lag_run.Rd (different file)
- No other PRs touch fill_run.Rd

## Stata Migration Relevance

The `fill_run()` function is useful for Stata users migrating to R, as it provides functionality similar to Stata's `fill` command for carrying forward values. Clear documentation of the `run_for_first` parameter helps Stata users understand how to handle initial missing values, which is a common data cleaning operation.

## PR URL

https://github.com/gogonzo/runner/pull/116